### PR TITLE
Fix bug: var_export does not handle circular references

### DIFF
--- a/Controller/Process/Index.php
+++ b/Controller/Process/Index.php
@@ -170,7 +170,6 @@ class Index extends Action implements HttpPostActionInterface, CsrfAwareActionIn
                     $order->setStatus('platon_payment_successful')
                         ->save();
 
-                    $this->logger->info(var_export($order, true));
                     $this->logger->info("Order {$data['order']} processed as successfull sale");
                     break;
                 case 'REFUND':


### PR DESCRIPTION
Попытка выгрузить дамп объекта $order в лог приводит к _PHP message: PHP Warning:  Uncaught Exception: Warning: var_export does not handle circular references in Controller/Process/Index.php on line 174_