### PR TITLE
Add callback-logger

### DIFF
--- a/Controller/Process/Index.php
+++ b/Controller/Process/Index.php
@@ -14,7 +14,7 @@ use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Session\SessionManager;
 use Magento\Framework\View\Result\PageFactory;
 use Magento\Sales\Model\Order;
-use Psr\Log\LoggerInterface;
+use Platon\PlatonPay\Model\Logger\Logger;
 use Magento\Sales\Model\Order\Email\Sender\OrderSender;
 
 class Index extends Action implements HttpPostActionInterface, CsrfAwareActionInterface
@@ -59,7 +59,7 @@ class Index extends Action implements HttpPostActionInterface, CsrfAwareActionIn
     protected $session_manager;
 
     /**
-     * @var LoggerInterface
+     * @var Logger
      */
     protected $logger;
 
@@ -76,7 +76,7 @@ class Index extends Action implements HttpPostActionInterface, CsrfAwareActionIn
      * @param PageFactory     $pageFactory
      * @param Session         $session
      * @param SessionManager  $session_manager
-     * @param LoggerInterface $logger
+     * @param Logger          $logger
      * @param Order           $order
      * @param OrderSender     $order_sender
      */
@@ -85,7 +85,7 @@ class Index extends Action implements HttpPostActionInterface, CsrfAwareActionIn
         PageFactory $pageFactory,
         Session $session,
         SessionManager $session_manager,
-        LoggerInterface $logger,
+        Logger $logger,
         Order $order,
         OrderSender $order_sender
     ) {

--- a/Model/Logger/Handler.php
+++ b/Model/Logger/Handler.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Platon\PlatonPay\Model\Logger;
+
+class Handler extends \Magento\Framework\Logger\Handler\Base
+{
+    /**
+     * Logging level
+     * @var int
+     */
+    protected $loggerType = \Monolog\Logger::DEBUG;
+
+    /**
+     * File name
+     * @var string
+     */
+    protected $fileName = '/var/log/platon_callback.log';
+}

--- a/Model/Logger/Logger.php
+++ b/Model/Logger/Logger.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Platon\PlatonPay\Model\Logger;
+
+class Logger extends \Monolog\Logger
+{
+
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -140,4 +140,20 @@
         </arguments>
     </type>
 
+    <!-- Callback Logger -->>
+    <type name="Platon\PlatonPay\Model\Logger\Handler">
+        <arguments>
+            <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
+        </arguments>
+    </type>
+
+    <type name="Platon\PlatonPay\Model\Logger\Logger">
+        <arguments>
+            <argument name="name" xsi:type="string">PlatonLogger</argument>
+            <argument name="handlers"  xsi:type="array">
+                <item name="system" xsi:type="object">Platon\PlatonPay\Model\Logger\Handler</item>
+            </argument>
+        </arguments>
+    </type>
+
 </config>


### PR DESCRIPTION
Реалізація callback-логування згідно інструкції:

> Примітка: взаємодія CMS і gateway пишеться в лог за адресою: /{PATH}/var/log/platon_callback.log – переконайтеся, що ця директорія доступна для запису веб-сервера. 

Зараз лог пишеться в debug.log